### PR TITLE
Update ex_hello_license.rb

### DIFF
--- a/examples/99_license/ex_hello_license.rb
+++ b/examples/99_license/ex_hello_license.rb
@@ -8,7 +8,7 @@ module Examples
   module HelloLicense
 
     unless file_loaded?(__FILE__)
-      ex = SketchupExtension.new('Hello Cube', 'ex_hello_cube/main')
+      ex = SketchupExtension.new('Hello Cube', 'ex_hello_license/main')
       ex.description = 'SketchUp Ruby API example creating a cube.'
       ex.version     = '1.0.0'
       ex.copyright   = 'Trimble Navigations © 2016'


### PR DESCRIPTION
# Problem...
Error Loading File ex_hello_cube/main
Could not find included file 'ex_hello_cube/main'
ex = SketchupExtension.new('Hello Cube', 'ex_hello_cube/main')

#Solution...
ex = SketchupExtension.new('Hello Cube', 'ex_hello_license/main')