### PR TITLE
Add examples of VCB support, press+drag+release support and inference support

### DIFF
--- a/examples/01_hello_cube/ex_hello_cube/main.rb
+++ b/examples/01_hello_cube/ex_hello_cube/main.rb
@@ -24,7 +24,7 @@ module Examples
 
     unless file_loaded?(__FILE__)
       menu = UI.menu('Plugins')
-      menu.add_item('Create Cube Example') {
+      menu.add_item('01 Create Cube Example') {
         self.create_cube
       }
       file_loaded(__FILE__)

--- a/examples/02_custom_tool/ex_custom_tool.rb
+++ b/examples/02_custom_tool/ex_custom_tool.rb
@@ -2,7 +2,7 @@
 # Licensed under the MIT license
 
 # This demonstrate how to create a custom Ruby tool that lets the user pick
-# points in the model to create a cube.
+# points in the model to draw edges.
 
 require 'sketchup.rb'
 require 'extensions.rb'

--- a/examples/02_custom_tool/ex_custom_tool/main.rb
+++ b/examples/02_custom_tool/ex_custom_tool/main.rb
@@ -134,7 +134,7 @@ module Examples
 
     unless file_loaded?(__FILE__)
       menu = UI.menu('Plugins')
-      menu.add_item('Custom Tool Example') {
+      menu.add_item('02 Custom Tool Example') {
         self.activate_line_tool
       }
       file_loaded(__FILE__)

--- a/examples/03_press_drag_release_tool/README.md
+++ b/examples/03_press_drag_release_tool/README.md
@@ -1,0 +1,7 @@
+# Press+Drag+Release Tool
+
+This demonstrates how a tool can be improved to feel more SketchUp like by
+supporting optional press+drag+release drawing style, in addition to the normal
+click+move+click.
+
+This is a continuation of "02_custom_tool".

--- a/examples/03_press_drag_release_tool/ex_press_drag_release_tool.rb
+++ b/examples/03_press_drag_release_tool/ex_press_drag_release_tool.rb
@@ -1,0 +1,24 @@
+# Copyright 2021 Trimble Inc
+# Licensed under the MIT license
+
+# This demonstrate how to improve a custom Ruby tool to allow optional
+# press+drag+release drawing style.
+
+require 'sketchup.rb'
+require 'extensions.rb'
+
+module Examples
+  module PressDragReleaseTool
+
+    unless file_loaded?(__FILE__)
+      ex = SketchupExtension.new('Press+Drag+Release Tool', 'ex_press_drag_release_tool/main')
+      ex.description = 'SketchUp Ruby API example for press+drag+release drawing style.'
+      ex.version     = '1.0.0'
+      ex.copyright   = 'Trimble Inc © 2021'
+      ex.creator     = 'SketchUp'
+      Sketchup.register_extension(ex, true)
+      file_loaded(__FILE__)
+    end
+
+  end
+end

--- a/examples/04_vcb_tool/README.md
+++ b/examples/04_vcb_tool/README.md
@@ -1,0 +1,6 @@
+# Measurement Bar Tool
+
+This demonstrates how a tool can be improved to feel more SketchUp like by
+taking text input in the measurement bar (aka VCB).
+
+This is a continuation of "03_press_drag_release".

--- a/examples/04_vcb_tool/ex_vcb_tool.rb
+++ b/examples/04_vcb_tool/ex_vcb_tool.rb
@@ -1,0 +1,24 @@
+# Copyright 2021 Trimble Inc
+# Licensed under the MIT license
+
+# This demonstrate how to improve a custom Ruby tool to allow precise text input
+# in the measurement bar (aka VCB).
+
+require 'sketchup.rb'
+require 'extensions.rb'
+
+module Examples
+  module VCBTool
+
+    unless file_loaded?(__FILE__)
+      ex = SketchupExtension.new('Measurement Bar', 'ex_vcb_tool/main')
+      ex.description = 'SketchUp Ruby API example of tool Measurement Bar support.'
+      ex.version     = '1.0.0'
+      ex.copyright   = 'Trimble Inc © 2021'
+      ex.creator     = 'SketchUp'
+      Sketchup.register_extension(ex, true)
+      file_loaded(__FILE__)
+    end
+
+  end
+end

--- a/examples/04_vcb_tool/ex_vcb_tool/main.rb
+++ b/examples/04_vcb_tool/ex_vcb_tool/main.rb
@@ -1,21 +1,36 @@
-# Copyright 2016 Trimble Inc
+# Copyright 2021 Trimble Inc
 # Licensed under the MIT license
 
 require 'sketchup.rb'
 
 module Examples
-  module CustomTool
+  module VCBTool
 
     class LineTool
+
+      # Threshold in logical screen pixels for when the mouse is considered to
+      # be dragged.
+      DRAG_THRESHOLD = 10
 
       def activate
         @mouse_ip = Sketchup::InputPoint.new
         @picked_first_ip = Sketchup::InputPoint.new
+
+        # Track where mouse was pressed down so we can compare its position when
+        # later released.
+        @mouse_down = ORIGIN
+
         update_ui
       end
 
       def deactivate(view)
         view.invalidate
+      end
+
+      # Enable editing in the measurement bar when the first point has been
+      # picked.
+      def enableVCB?
+        picked_first_point?
       end
 
       def resume(view)
@@ -35,6 +50,11 @@ module Examples
       def onMouseMove(flags, x, y, view)
         if picked_first_point?
           @mouse_ip.pick(view, x, y, @picked_first_ip)
+
+          # Print the length of the previewed line to the measurement bar.
+          # Printing a Length object (as opposed to a float) automatically
+          # formats it according to the model units.
+          Sketchup.vcb_value = @mouse_ip.position.distance(@picked_first_ip.position)
         else
           @mouse_ip.pick(view, x, y)
         end
@@ -43,6 +63,9 @@ module Examples
       end
 
       def onLButtonDown(flags, x, y, view)
+        # Track where in screen space mouse is pressed down.
+        @mouse_down = Geom::Point3d.new(x, y)
+
         if picked_first_point? && create_edge > 0
           # When the user have picked a start point and then picks another point
           # we create an edge and try to create new faces from that edge.
@@ -58,17 +81,56 @@ module Examples
         view.invalidate
       end
 
+      def onLButtonUp(flags, x, y, view)
+        if @mouse_down.distance([x, y]) > DRAG_THRESHOLD
+          # Mouse is released far enough away from where it was pressed to be
+          # considered to be dragged there.
+
+          create_edge
+
+          # When drag-drawing, it feels odd to chain line drawing and we
+          # consistently reset the tool instead.
+          # You can try only calling this method if create_edge returns a
+          # positive number, to experience the other behavior.
+          reset_tool
+        end
+      end
+
       # Here we have hard coded a special ID for the pencil cursor in SketchUp.
       # Normally you would use `UI.create_cursor(cursor_path, 0, 0)` instead
       # with your own custom cursor bitmap:
       #
       #   CURSOR_PENCIL = UI.create_cursor(cursor_path, 0, 0)
       CURSOR_PENCIL = 632
+
       def onSetCursor
         # Note that `onSetCursor` is called frequently so you should not do much
         # work here. At most you switch between different cursor representing
         # the state of the tool.
         UI.set_cursor(CURSOR_PENCIL)
+      end
+
+      # Listen to measurement bar text input.
+      def onUserText(text, view)
+        begin
+          distance = text.to_l
+        rescue ArgumentError
+          UI.messagebox('Invalid length')
+          return
+        end
+        direction = picked_points[1] - picked_points[0]
+        end_point = picked_points[0].offset(direction, distance)
+        @mouse_ip = Sketchup::InputPoint.new(end_point)
+
+        # If faces are created when creating the edge, reset the tool.
+        # Otherwise keep drawing edges.
+        if create_edge > 0
+          reset_tool
+        else
+          @picked_first_ip.copy!(@mouse_ip)
+        end
+
+        view.invalidate
       end
 
       def draw(view)
@@ -90,6 +152,8 @@ module Examples
         else
           Sketchup.status_text = 'Select start point.'
         end
+
+        Sketchup.vcb_label = 'Length'
       end
 
       def reset_tool
@@ -137,11 +201,11 @@ module Examples
 
     unless file_loaded?(__FILE__)
       menu = UI.menu('Plugins')
-      menu.add_item('02 Custom Tool Example') {
+      menu.add_item('04 Measurement Bar Tool Example') {
         self.activate_line_tool
       }
       file_loaded(__FILE__)
     end
 
-  end # module CustomTool
-end # module Examples
+  end
+end

--- a/examples/05_tool_inference_lock/README.md
+++ b/examples/05_tool_inference_lock/README.md
@@ -1,0 +1,6 @@
+# Tool Inference Lock
+
+This demonstrates how a tool can be improved to feel more SketchUp like by
+locking the inference with Shift and arrow keys.
+
+This is a continuation of "04_tool_vcb_support".

--- a/examples/05_tool_inference_lock/ex_tool_inference_lock.rb
+++ b/examples/05_tool_inference_lock/ex_tool_inference_lock.rb
@@ -1,0 +1,23 @@
+# Copyright 2021 Trimble Inc
+# Licensed under the MIT license
+
+# This demonstrate how to add inference locking to a tool.
+
+require 'sketchup.rb'
+require 'extensions.rb'
+
+module Examples
+  module ToolInferenceLock
+
+    unless file_loaded?(__FILE__)
+      ex = SketchupExtension.new('Tool Inference Lock', 'ex_tool_inference_lock/main')
+      ex.description = 'SketchUp Ruby API example of tool inference lock.'
+      ex.version     = '1.0.0'
+      ex.copyright   = 'Trimble Inc © 2021'
+      ex.creator     = 'SketchUp'
+      Sketchup.register_extension(ex, true)
+      file_loaded(__FILE__)
+    end
+
+  end
+end

--- a/examples/05_tool_inference_lock/ex_tool_inference_lock/inference_lock_helper.rb
+++ b/examples/05_tool_inference_lock/ex_tool_inference_lock/inference_lock_helper.rb
@@ -1,0 +1,117 @@
+module Examples
+  module ToolInferenceLock
+    # Helper object to lock tool inference using Shift or arrow keys.
+    class InferenceLockHelper
+      # Create InferenceLockHelper object.
+      def initialize
+        @axis_lock = nil
+        @mouse_x = nil
+        @mouse_y = nil
+      end
+
+      # Call this method from +onKeyDown+.
+      #
+      # After calling this method, also re-pick your input point, as the
+      # inference lock may have changed.
+      #
+      # @param key [Integer]
+      # @param view [Sketchup::View]
+      # @param active_ip [Sketchup::InputPoint]
+      #   The InputPoint currently used to pick points.
+      # @param reference_ip [Sketchup::InputPoint]
+      #   An InputPoint marking where the current operation was started.
+      def on_keydown(key, view, active_ip, reference_ip = active_ip)
+        if key == CONSTRAIN_MODIFIER_KEY
+          try_lock_constraint(view, active_ip)
+        else
+          try_lock_axis(key, view, reference_ip)
+        end
+      end
+
+      # Call this method from +onKeyUp+.
+      #
+      # After calling this method, also re-pick your input point, as the
+      # inference lock may have changed.
+      #
+      # @param key [Integer]
+      # @param view [Sketchup::View]
+      def on_keyup(key, view)
+        return unless key == CONSTRAIN_MODIFIER_KEY
+        return if @axis_lock
+
+        # Calling this method with no argument unlocks inference.
+        view.lock_inference
+      end
+
+      # Remove any inference locking.
+      # This should typically be called when the user resets the tool.
+      # Removing inference locking using Shift and arrow keys is handled by
+      # +handle_keydown+ and +handle_keyup+.
+      def unlock
+        @axis_lock = nil
+        # Calling this method with no argument unlocks inference.
+        Sketchup.active_model.active_view.lock_inference
+      end
+
+      private
+
+      # Try picking a constraint lock.
+      #
+      # @param view [Sketchup::View]
+      # @param active_ip [Sketchup::InputPoint]
+      #   The InputPoint currently used to pick points.
+      def try_lock_constraint(view, active_ip)
+        return if @axis_lock
+        return unless active_ip.valid?
+
+        view.lock_inference(active_ip)
+      end
+
+      # Try picking an axis lock for given keycode.
+      #
+      # @param key [Integer]
+      # @param view [Sketchup::View]
+      # @param reference_ip [Sketchup::InputPoint]
+      #   An InputPoint marking where the current operation was started.
+      def try_lock_axis(key, view, reference_ip)
+        return unless reference_ip.valid?
+
+        case key
+        when VK_RIGHT
+          lock_inference_axis([reference_ip.position, view.model.axes.xaxis], view)
+        when VK_LEFT
+          lock_inference_axis([reference_ip.position, view.model.axes.yaxis], view)
+        when VK_UP
+          lock_inference_axis([reference_ip.position, view.model.axes.zaxis], view)
+        end
+      end
+
+      # Unlock inference lock to axis, if there is any.
+      #
+      # @param view [Sketchup::view]
+      def unlock_axis(view)
+        # Any inference lock not done with `lock_inference_axis` should be kept.
+        # This method is only concerned with inference locks to the axes.
+        return unless @axis_lock
+
+        @axis_lock = nil
+        # Calling this method with no argument unlocks inference.
+        view.lock_inference
+      end
+
+      # Lock inference to an axis or unlock if already locked to that very axis.
+      #
+      # @param line [Array<(Geom::Point3d, Geom::Vector3d)>]
+      # @param view [Sketchup::View]
+      def lock_inference_axis(line, view)
+        return unlock_axis(view) if line == @axis_lock
+
+        @axis_lock = line
+        view.lock_inference(
+          Sketchup::InputPoint.new(line[0]),
+          Sketchup::InputPoint.new(line[0].offset(line[1]))
+        )
+      end
+    end
+  end
+end

--- a/examples/05_tool_inference_lock/ex_tool_inference_lock/main.rb
+++ b/examples/05_tool_inference_lock/ex_tool_inference_lock/main.rb
@@ -1,0 +1,247 @@
+# Copyright 2021 Trimble Inc
+# Licensed under the MIT license
+
+require 'sketchup.rb'
+require 'ex_tool_inference_lock/inference_lock_helper'
+
+module Examples
+  module ToolInferenceLock
+
+    class LineTool
+
+      # Threshold in logical screen pixels for when the mouse is considered to
+      # be dragged.
+      DRAG_THRESHOLD = 10
+
+      def activate
+        @mouse_ip = Sketchup::InputPoint.new
+        @picked_first_ip = Sketchup::InputPoint.new
+        @mouse_position = ORIGIN
+        @mouse_down = ORIGIN
+        @distance = 0
+
+        # Create a InferenceLockHelper object to use in this tool.
+        # See inference_lock_helper.rb for details.
+        @inference_lock_helper = InferenceLockHelper.new
+
+        update_ui
+      end
+
+      def deactivate(view)
+        @inference_lock_helper.unlock
+        view.invalidate
+      end
+
+      def enableVCB?
+        picked_first_point?
+      end
+
+      def resume(view)
+        update_ui
+        view.invalidate
+      end
+
+      def suspend(view)
+        view.invalidate
+      end
+
+      def onCancel(reason, view)
+        reset_tool
+        view.invalidate
+      end
+
+      def onKeyDown(key, _repeat, _flags, view)
+        @inference_lock_helper.on_keydown(key, view, @mouse_ip, @picked_first_ip)
+        pick_mouse_position(view)
+      end
+
+      def onKeyUp(key, _repeat, _flags, view)
+        @inference_lock_helper.on_keyup(key, view)
+        pick_mouse_position(view)
+      end
+
+      def onMouseMove(flags, x, y, view)
+        # Memorize mouse positions so we can do the InputPoint picking again
+        # when inference lock changes.
+        @mouse_position = Geom::Point3d.new(x, y, 0)
+
+        # Breaking out the normal mouse move logic to a method that can also be
+        # called when inference lock changes.
+        pick_mouse_position(view)
+      end
+
+      def onLButtonDown(flags, x, y, view)
+        @mouse_down = Geom::Point3d.new(x, y)
+
+        if picked_first_point? && create_edge > 0
+          # When the user have picked a start point and then picks another point
+          # we create an edge and try to create new faces from that edge.
+          # Like the native tool we reset the tool if it created new faces.
+          reset_tool
+        else
+          # If no face was created we let the user chain new edges to the last
+          # input point.
+          @picked_first_ip.copy!(@mouse_ip)
+        end
+
+        update_ui
+        view.invalidate
+      end
+
+      def onLButtonUp(flags, x, y, view)
+        if @mouse_down.distance([x, y]) > DRAG_THRESHOLD
+          create_edge
+          reset_tool
+        end
+      end
+
+      # Here we have hard coded a special ID for the pencil cursor in SketchUp.
+      # Normally you would use `UI.create_cursor(cursor_path, 0, 0)` instead
+      # with your own custom cursor bitmap:
+      #
+      #   CURSOR_PENCIL = UI.create_cursor(cursor_path, 0, 0)
+      CURSOR_PENCIL = 632
+
+      def onSetCursor
+        # Note that `onSetCursor` is called frequently so you should not do much
+        # work here. At most you switch between different cursor representing
+        # the state of the tool.
+        UI.set_cursor(CURSOR_PENCIL)
+      end
+
+      def onUserText(text, view)
+        begin
+          distance = text.to_l
+        rescue ArgumentError
+          UI.messagebox('Invalid length')
+          return
+        end
+        direction = picked_points[1] - picked_points[0]
+        end_point = picked_points[0].offset(direction, distance)
+        @mouse_ip = Sketchup::InputPoint.new(end_point)
+
+        # If faces are created when creating the edge, reset the tool.
+        # Otherwise keep drawing edges.
+        if create_edge > 0
+          reset_tool
+        else
+          @picked_first_ip.copy!(@mouse_ip)
+        end
+
+        view.invalidate
+      rescue ArgumentError
+        Ui.messagebox('Invalid length')
+      end
+
+      def draw(view)
+        draw_preview(view)
+
+        view.line_width = 1
+        @mouse_ip.draw(view) if @mouse_ip.display?
+      end
+
+      def getExtents
+        bounds = Geom::BoundingBox.new
+        bounds.add(picked_points)
+        bounds
+      end
+
+      private
+
+      # This is the input point picking logic you typically see in OnMouseMove.
+      # This code is broken out as a separate method to be able to update the
+      # input points when the inference lock changes.
+      def pick_mouse_position(view)
+        if picked_first_point?
+          @mouse_ip.pick(view, @mouse_position.x, @mouse_position.y, @picked_first_ip)
+          @distance = @mouse_ip.position.distance(@picked_first_ip.position)
+          update_ui
+        else
+          @mouse_ip.pick(view, @mouse_position.x, @mouse_position.y)
+        end
+        view.tooltip = @mouse_ip.tooltip if @mouse_ip.valid?
+        view.invalidate
+      end
+
+      def update_ui
+        # We specifically do not bloat the status text with all the arrow keys
+        # and Shift key, as those are more or less universal in SketchUp.
+        # Adding too much text just makes the status bar hard to read.
+        # However, the instructor should mention these.
+        if picked_first_point?
+          Sketchup.status_text = 'Select end point.'
+          Sketchup.vcb_value = @distance
+        else
+          Sketchup.status_text = 'Select start point.'
+        end
+
+        Sketchup.vcb_label = 'Length'
+      end
+
+      def reset_tool
+        @picked_first_ip.clear
+
+        # Unlock inference when resetting the tool.
+        # If the user isn't happy with the starting point, they likely aren't
+        # happy with any inference lock either.
+        @inference_lock_helper.unlock
+
+        update_ui
+      end
+
+      def picked_first_point?
+        @picked_first_ip.valid?
+      end
+
+      def picked_points
+        points = []
+        points << @picked_first_ip.position if picked_first_point?
+        points << @mouse_ip.position if @mouse_ip.valid?
+        points
+      end
+
+      def draw_preview(view)
+        points = picked_points
+        return unless points.size == 2
+
+        # When inference is locked, draw the lines 3 pixels wide.
+        # This subtly but clearly the line now "snaps" into a certain direction.
+        view.line_width = view.inference_locked? ? 3 : 1
+
+        view.set_color_from_line(*points)
+        view.draw(GL_LINES, points)
+      end
+
+      # Returns the number of created faces.
+      def create_edge
+        model = Sketchup.active_model
+        model.start_operation('Edge', true)
+        edge = model.active_entities.add_line(picked_points)
+        num_faces = edge.find_faces || 0 # API returns nil instead of 0.
+        model.commit_operation
+
+        # Remove any inference lock once an edge is drawn.
+        # Typically you don't want more than one edge locked to a single line or
+        # plane.
+        @inference_lock_helper.unlock
+
+        num_faces
+      end
+
+    end # class LineTool
+
+
+    def self.activate_line_tool
+      Sketchup.active_model.select_tool(LineTool.new)
+    end
+
+    unless file_loaded?(__FILE__)
+      menu = UI.menu('Plugins')
+      menu.add_item('05 Tool Inference Lock Example') {
+        self.activate_line_tool
+      }
+      file_loaded(__FILE__)
+    end
+
+  end
+end

--- a/examples/99_hello_donut/ex_hello_donut/main.rb
+++ b/examples/99_hello_donut/ex_hello_donut/main.rb
@@ -30,7 +30,7 @@ module Examples
 
     unless file_loaded?(__FILE__)
       menu = UI.menu('Plugins')
-      menu.add_item('Create Donut Example') {
+      menu.add_item('99 Create Donut Example') {
         self.create_donut
       }
       file_loaded(__FILE__)

--- a/examples/99_hello_sphere/ex_hello_sphere/main.rb
+++ b/examples/99_hello_sphere/ex_hello_sphere/main.rb
@@ -28,7 +28,7 @@ module Examples
 
     unless file_loaded?(__FILE__)
       menu = UI.menu('Plugins')
-      menu.add_item('Create Sphere Example') {
+      menu.add_item('99 Create Sphere Example') {
         self.create_sphere
       }
       file_loaded(__FILE__)

--- a/examples/99_license/ex_hello_license/main.rb
+++ b/examples/99_license/ex_hello_license/main.rb
@@ -39,7 +39,7 @@ module Examples
       # the commands themselves to have a license check. As seen in the example
       # above, it's recommended to provide a message back to the user.
       menu = UI.menu('Plugins')
-      menu.add_item('Create Cube Example') {
+      menu.add_item('99 Create Cube Example') {
         self.create_cube
       }
       file_loaded(__FILE__)

--- a/examples/99_sphere_tool/ex_sphere_tool/main.rb
+++ b/examples/99_sphere_tool/ex_sphere_tool/main.rb
@@ -24,6 +24,10 @@ module Examples
         view.invalidate
       end
 
+      def suspend(view)
+        view.invalidate
+      end
+
       def onCancel(reason, view)
         reset_tool
         view.invalidate
@@ -216,23 +220,24 @@ module Examples
       # feeding it all the points, just compute the extremes in XYZ directions
       # from the sphere center.
       def sphere_bounds
-        bb = Geom::BoundingBox.new
+        bounds = Geom::BoundingBox.new
         if @picked_first_ip.valid? && @mouse_ip.valid?
           origin = @picked_first_ip.position
           x_axis = origin.vector_to(@mouse_ip)
-          return bb unless x_axis.valid?
+          return bounds unless x_axis.valid?
+
           y_axis = x_axis.axes.x
           y_axis.length = x_axis.length
           z_axis = x_axis.axes.y
           z_axis.length = x_axis.length
-          bb.add(origin.offset(x_axis))
-          bb.add(origin.offset(x_axis.reverse))
-          bb.add(origin.offset(y_axis))
-          bb.add(origin.offset(y_axis.reverse))
-          bb.add(origin.offset(z_axis))
-          bb.add(origin.offset(z_axis.reverse))
+          bounds.add(origin.offset(x_axis))
+          bounds.add(origin.offset(x_axis.reverse))
+          bounds.add(origin.offset(y_axis))
+          bounds.add(origin.offset(y_axis.reverse))
+          bounds.add(origin.offset(z_axis))
+          bounds.add(origin.offset(z_axis.reverse))
         end
-        bb
+        bounds
       end
 
       def sphere_preview_points(origin, x_axis, radius, segments = 24)

--- a/examples/99_sphere_tool/ex_sphere_tool/main.rb
+++ b/examples/99_sphere_tool/ex_sphere_tool/main.rb
@@ -282,7 +282,7 @@ module Examples
 
     unless file_loaded?(__FILE__)
       menu = UI.menu('Plugins')
-      menu.add_item('Sphere Tool Example') {
+      menu.add_item('99 Sphere Tool Example') {
         self.activate_sphere_tool
       }
       file_loaded(__FILE__)

--- a/tutorials/01_hello_cube/tut_hello_cube/main.rb
+++ b/tutorials/01_hello_cube/tut_hello_cube/main.rb
@@ -85,7 +85,7 @@ module Examples
       # We add the menu item directly to the root of the menu in this example.
       # But if you plan to add multiple items per extension we recommend you
       # group them into a sub-menu in order to keep things organized.
-      menu.add_item('Create Cube Example') {
+      menu.add_item('01 Create Cube Example') {
         self.create_cube
       }
 

--- a/tutorials/02_custom_tool/tut_custom_tool/main.rb
+++ b/tutorials/02_custom_tool/tut_custom_tool/main.rb
@@ -196,7 +196,7 @@ module Examples
 
     unless file_loaded?(__FILE__)
       menu = UI.menu('Plugins')
-      menu.add_item('Custom Tool Example') {
+      menu.add_item('02 Custom Tool Example') {
         self.activate_line_tool
       }
       file_loaded(__FILE__)

--- a/tutorials/02_custom_tool/tut_custom_tool/main.rb
+++ b/tutorials/02_custom_tool/tut_custom_tool/main.rb
@@ -33,7 +33,7 @@ module Examples
       # This is called when the user switches to a different tool. It's
       # recommended to always call view.invalidate in order to make sure we
       # clear out any custom drawings done to the viewport. Otherwise these
-      # drawings might linger around for a moment confusing the user.
+      # drawings might linger around for a moment, confusing the user.
       def deactivate(view)
         view.invalidate
       end


### PR DESCRIPTION
Add example/tutorial 03 showing how to support VCB input and optional press+drag+release drawing style.

Add example/tutorial 04 showing how to support inference locking using a third party library.

Simplified onLButtonDown logic in example/tutorial 02. I struggled to understand the existing flow where a face count being 0 could both represent an edge was drawn but no faces could be formed, and the user made the initial click.